### PR TITLE
Feat/4 new makespecial command

### DIFF
--- a/src/main/kotlin/dev/slne/surf/essentials/PaperCommandManager.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/PaperCommandManager.kt
@@ -92,5 +92,6 @@ object PaperCommandManager {
         soundCommand()
         stopCommand()
         restartCommand()
+        makeSpecialCommand()
     }
 }

--- a/src/main/kotlin/dev/slne/surf/essentials/PaperListenerManager.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/PaperListenerManager.kt
@@ -10,5 +10,6 @@ object PaperListenerManager {
         GameModeSwitcherCorrectionListener.register()
         TeleportationListener.register()
         UnknownCommandListener.register()
+        SpecialItemListener.register()
     }
 }

--- a/src/main/kotlin/dev/slne/surf/essentials/command/MakeSpecialCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/MakeSpecialCommand.kt
@@ -20,6 +20,7 @@ fun makeSpecialCommand() = commandTree("makespecial") {
         }
 
         specialItemService.makeSpecial(itemInHand)
+        specialItemService.unMarkAsAnnounced(itemInHand)
 
         player.sendText {
             appendPrefix()

--- a/src/main/kotlin/dev/slne/surf/essentials/command/MakeSpecialCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/MakeSpecialCommand.kt
@@ -1,0 +1,29 @@
+package dev.slne.surf.essentials.command
+
+import dev.jorel.commandapi.kotlindsl.commandTree
+import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.slne.surf.essentials.service.specialItemService
+import dev.slne.surf.essentials.util.permission.EssentialsPermissionRegistry
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+
+fun makeSpecialCommand() = commandTree("makespecial") {
+    withPermission(EssentialsPermissionRegistry.MAKE_SPECIAL_COMMAND)
+    playerExecutor { player, _ ->
+        val itemInHand = player.inventory.itemInMainHand
+
+        if (itemInHand.type.isAir) {
+            player.sendText {
+                appendPrefix()
+                error("Du musst ein Item in der Hand halten.")
+            }
+            return@playerExecutor
+        }
+
+        specialItemService.makeSpecial(itemInHand)
+
+        player.sendText {
+            appendPrefix()
+            success("Das Item wurde als Spezialitem markiert.")
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/essentials/listener/SpecialItemListener.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/listener/SpecialItemListener.kt
@@ -1,0 +1,39 @@
+package dev.slne.surf.essentials.listener
+
+import dev.slne.surf.essentials.service.specialItemService
+import dev.slne.surf.essentials.util.util.translatable
+import dev.slne.surf.surfapi.bukkit.api.util.forEachPlayer
+import dev.slne.surf.surfapi.core.api.messages.Colors
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityPickupItemEvent
+
+object SpecialItemListener : Listener {
+    @EventHandler
+    fun onPickup(event: EntityPickupItemEvent) {
+        val player = event.entity as? Player ?: return
+        val itemStack = event.item.itemStack
+
+        if (!specialItemService.isSpecial(itemStack)) {
+            return
+        }
+
+        if (specialItemService.isAnnounced(itemStack)) {
+            return
+        }
+
+        specialItemService.markAsAnnounced(itemStack)
+
+        forEachPlayer {
+            it.sendText {
+                appendPrefix()
+                variableValue(player.name)
+                success(" hat ")
+                translatable(itemStack.translationKey()).colorIfAbsent(Colors.VARIABLE_VALUE)
+                success(" erhalten!")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/essentials/listener/SpecialItemListener.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/listener/SpecialItemListener.kt
@@ -5,6 +5,8 @@ import dev.slne.surf.essentials.util.util.translatable
 import dev.slne.surf.surfapi.bukkit.api.util.forEachPlayer
 import dev.slne.surf.surfapi.core.api.messages.Colors
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import dev.slne.surf.surfapi.core.api.messages.adventure.sound
+import org.bukkit.Sound
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -16,19 +18,13 @@ object SpecialItemListener : Listener {
         val player = event.entity as? Player ?: return
         val itemStack = event.item.itemStack
 
-        println("Item picked up: ${itemStack.type}, amount: ${itemStack.amount}")
-
         if (!specialItemService.isSpecial(itemStack)) {
-            println("Item is not special.")
             return
         }
 
         if (specialItemService.isAnnounced(itemStack)) {
-            println("Item has already been announced.")
             return
         }
-
-        println("Item is special and has not been announced yet.")
 
         specialItemService.markAsAnnounced(itemStack)
 
@@ -37,9 +33,17 @@ object SpecialItemListener : Listener {
                 appendPrefix()
                 variableValue(player.name)
                 success(" hat ")
-                translatable(itemStack.translationKey()).colorIfAbsent(Colors.VARIABLE_VALUE)
+
+                append {
+                    translatable(itemStack.translationKey()).colorIfAbsent(Colors.VARIABLE_VALUE)
+                    hoverEvent(itemStack.asHoverEvent())
+                }
                 success(" erhalten!")
             }
+
+            it.playSound(sound {
+                type(Sound.ENTITY_ENDER_DRAGON_GROWL)
+            }, net.kyori.adventure.sound.Sound.Emitter.self())
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/essentials/listener/SpecialItemListener.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/listener/SpecialItemListener.kt
@@ -16,13 +16,19 @@ object SpecialItemListener : Listener {
         val player = event.entity as? Player ?: return
         val itemStack = event.item.itemStack
 
+        println("Item picked up: ${itemStack.type}, amount: ${itemStack.amount}")
+
         if (!specialItemService.isSpecial(itemStack)) {
+            println("Item is not special.")
             return
         }
 
         if (specialItemService.isAnnounced(itemStack)) {
+            println("Item has already been announced.")
             return
         }
+
+        println("Item is special and has not been announced yet.")
 
         specialItemService.markAsAnnounced(itemStack)
 

--- a/src/main/kotlin/dev/slne/surf/essentials/service/SpecialItemService.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/service/SpecialItemService.kt
@@ -1,0 +1,37 @@
+package dev.slne.surf.essentials.service
+
+import dev.slne.surf.essentials.plugin
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemStack
+import org.bukkit.persistence.PersistentDataType
+
+class SpecialItemService {
+    private val specialKey = NamespacedKey(plugin, "special")
+    private val specialAnnounced = NamespacedKey(plugin, "special_announced")
+
+    fun makeSpecial(item: ItemStack) = item.itemMeta.persistentDataContainer.set(
+        specialKey,
+        PersistentDataType.BOOLEAN, true
+    )
+
+    fun isSpecial(item: ItemStack) = item.itemMeta.persistentDataContainer.has(
+        specialKey,
+        PersistentDataType.BOOLEAN
+    )
+
+    fun markAsAnnounced(item: ItemStack) = item.itemMeta.persistentDataContainer.set(
+        specialAnnounced,
+        PersistentDataType.BOOLEAN, true
+    )
+
+    fun isAnnounced(item: ItemStack) = item.itemMeta.persistentDataContainer.has(
+        specialAnnounced,
+        PersistentDataType.BOOLEAN
+    )
+
+    companion object {
+        val INSTANCE = SpecialItemService()
+    }
+}
+
+val specialItemService get() = SpecialItemService.INSTANCE

--- a/src/main/kotlin/dev/slne/surf/essentials/service/SpecialItemService.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/service/SpecialItemService.kt
@@ -14,9 +14,9 @@ class SpecialItemService {
         PersistentDataType.BOOLEAN, true
     )
 
-    fun isSpecial(item: ItemStack) = item.itemMeta.persistentDataContainer.has(
+    fun isSpecial(item: ItemStack): Boolean = item.itemMeta.persistentDataContainer.getOrDefault(
         specialKey,
-        PersistentDataType.BOOLEAN
+        PersistentDataType.BOOLEAN, false
     )
 
     fun markAsAnnounced(item: ItemStack) = item.itemMeta.persistentDataContainer.set(

--- a/src/main/kotlin/dev/slne/surf/essentials/service/SpecialItemService.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/service/SpecialItemService.kt
@@ -9,20 +9,23 @@ class SpecialItemService {
     private val specialKey = NamespacedKey(plugin, "special")
     private val specialAnnounced = NamespacedKey(plugin, "special_announced")
 
-    fun makeSpecial(item: ItemStack) = item.itemMeta.persistentDataContainer.set(
-        specialKey,
-        PersistentDataType.BOOLEAN, true
-    )
+    fun makeSpecial(item: ItemStack) = item.editPersistentDataContainer {
+        it.set(specialKey, PersistentDataType.BOOLEAN, true)
+    }
+
 
     fun isSpecial(item: ItemStack): Boolean = item.itemMeta.persistentDataContainer.getOrDefault(
         specialKey,
         PersistentDataType.BOOLEAN, false
     )
 
-    fun markAsAnnounced(item: ItemStack) = item.itemMeta.persistentDataContainer.set(
-        specialAnnounced,
-        PersistentDataType.BOOLEAN, true
-    )
+    fun markAsAnnounced(item: ItemStack) = item.editPersistentDataContainer {
+        it.set(specialAnnounced, PersistentDataType.BOOLEAN, true)
+    }
+
+    fun unMarkAsAnnounced(item: ItemStack) = item.editPersistentDataContainer {
+        it.remove(specialAnnounced)
+    }
 
     fun isAnnounced(item: ItemStack) = item.itemMeta.persistentDataContainer.has(
         specialAnnounced,

--- a/src/main/kotlin/dev/slne/surf/essentials/util/permission/EssentialsPermissionRegistry.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/util/permission/EssentialsPermissionRegistry.kt
@@ -88,4 +88,5 @@ object EssentialsPermissionRegistry : PermissionRegistry() {
     val STOP_NOTIFY = create("$PREFIX.stop.notify")
     val RESTART_COMMAND = create("$PREFIX.restart.command")
     val RESTART_NOTIFY = create("$PREFIX.restart.notify")
+    val MAKE_SPECIAL_COMMAND = create("$PREFIX.makespecial.command")
 }


### PR DESCRIPTION
This pull request introduces a new "special item" system to the codebase, allowing players to mark items as special and triggering a global announcement when such items are picked up. The main changes include a new command for marking items as special, a listener for item pickup events, and a supporting service for managing special item metadata. Additionally, the necessary permissions and registrations have been added.

**Special Item Feature Implementation:**

* Added a new `MakeSpecialCommand` (`makeSpecialCommand`) that lets players mark the item in their hand as "special" via the `/makespecial` command. This command checks for the appropriate permission and provides user feedback. [[1]](diffhunk://#diff-fbba71845d67355ef89e28850c789687c977285bc5c24715ced85a9db30e08b1R1-R30) [[2]](diffhunk://#diff-97b54fd32a20abec032a971a8d62bc59b47013bfcd7dac8e9c25f142b745f7b4R91) [[3]](diffhunk://#diff-c1e3136cade7d519e3f64eda2193266136f82a9f5eeda4859fec9c5be9c80c98R95)
* Implemented the `SpecialItemService` singleton, which manages marking items as special, checking their status, and handling whether an item has been announced to players. This service uses the persistent data container to store metadata on items.

**Event Listener and Registration:**

* Added `SpecialItemListener`, which listens for item pickup events. When a player picks up a special item that hasn't been announced yet, all players receive an in-game message and sound effect announcing the pickup, and the item is marked as announced.
* Registered the new listener (`SpecialItemListener.register()`) and command (`makeSpecialCommand()`) in their respective manager objects to ensure they are active in the plugin lifecycle. [[1]](diffhunk://#diff-56c3b180f2d7c6b305dd8d844b49eee1a0c1b99cc3959f8048cbcc1bb25211b6R13) [[2]](diffhunk://#diff-c1e3136cade7d519e3f64eda2193266136f82a9f5eeda4859fec9c5be9c80c98R95)

**Permissions:**

* Introduced a new permission constant `MAKE_SPECIAL_COMMAND` in `EssentialsPermissionRegistry` to control access to the `/makespecial` command.

resolves #4 