### PR TITLE
feat: remove notification for disabled command in WorldCommand

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.10-2.0.3-SNAPSHOT
+version=1.21.10-2.0.4-SNAPSHOT

--- a/src/main/kotlin/dev/slne/surf/essentials/command/WorldCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/WorldCommand.kt
@@ -158,12 +158,6 @@ fun worldCommand() = commandTree("world") {
             anyExecutor { executor, args ->
                 val name: String by args
 
-                executor.sendText {
-                    appendPrefix()
-                    info("Dieser Befehl ist zurzeit deaktiviert.")
-                }
-                return@anyExecutor
-
                 if (Bukkit.getServer().isFolia()) {
                     executor.sendText {
                         appendPrefix()


### PR DESCRIPTION
This pull request makes a minor change to the `WorldCommand.kt` file by removing a block of code that previously sent a message indicating the command was disabled. The command logic will now continue to execute as normal, especially for Folia servers.