### PR TITLE
Feat/fully implement world system

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.10-2.0.4-SNAPSHOT
+version=1.21.10-2.0.5-SNAPSHOT

--- a/src/main/kotlin/dev/slne/surf/essentials/command/WorldCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/WorldCommand.kt
@@ -108,12 +108,6 @@ fun worldCommand() = commandTree("world") {
             anyExecutor { executor, args ->
                 val name: String by args
 
-                executor.sendText {
-                    appendPrefix()
-                    info("Dieser Befehl ist zurzeit deaktiviert.")
-                }
-                return@anyExecutor
-
                 if (Bukkit.getServer().isFolia()) {
                     executor.sendText {
                         appendPrefix()
@@ -132,12 +126,6 @@ fun worldCommand() = commandTree("world") {
             withPermission(EssentialsPermissionRegistry.WORLD_COMMAND_DELETE)
             anyExecutor { executor, args ->
                 val world: World by args
-
-                executor.sendText {
-                    appendPrefix()
-                    info("Dieser Befehl ist zurzeit deaktiviert.")
-                }
-                return@anyExecutor
 
                 if (Bukkit.getServer().isFolia()) {
                     executor.sendText {
@@ -158,12 +146,6 @@ fun worldCommand() = commandTree("world") {
             anyExecutor { executor, args ->
                 val name: String by args
 
-                executor.sendText {
-                    appendPrefix()
-                    info("Dieser Befehl ist zurzeit deaktiviert.")
-                }
-                return@anyExecutor
-
                 if (Bukkit.getServer().isFolia()) {
                     executor.sendText {
                         appendPrefix()
@@ -183,12 +165,6 @@ fun worldCommand() = commandTree("world") {
             withPermission(EssentialsPermissionRegistry.WORLD_COMMAND_UNLOAD)
             anyExecutor { executor, args ->
                 val world: World by args
-
-                executor.sendText {
-                    appendPrefix()
-                    info("Dieser Befehl ist zurzeit deaktiviert.")
-                }
-                return@anyExecutor
 
                 if (Bukkit.getServer().isFolia()) {
                     executor.sendText {

--- a/src/main/kotlin/dev/slne/surf/essentials/command/WorldCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/WorldCommand.kt
@@ -1,6 +1,8 @@
 package dev.slne.surf.essentials.command
 
 import dev.jorel.commandapi.kotlindsl.*
+import dev.slne.surf.essentials.command.argument.world.worldFoldersArgument
+import dev.slne.surf.essentials.command.argument.world.worldsArgument
 import dev.slne.surf.essentials.service.worldService
 import dev.slne.surf.essentials.util.permission.EssentialsPermissionRegistry
 import dev.slne.surf.essentials.util.util.isFolia
@@ -12,7 +14,7 @@ fun worldCommand() = commandTree("world") {
     withPermission(EssentialsPermissionRegistry.WORLD_COMMAND)
 
     literalArgument("lock") {
-        worldArgument("world") {
+        worldsArgument("world") {
             withPermission(EssentialsPermissionRegistry.WORLD_COMMAND_LOCK)
             anyExecutor { executor, args ->
                 val world: World by args
@@ -45,7 +47,7 @@ fun worldCommand() = commandTree("world") {
     }
 
     literalArgument("unlock") {
-        worldArgument("world") {
+        worldsArgument("world") {
             withPermission(EssentialsPermissionRegistry.WORLD_COMMAND_UNLOCK)
             anyExecutor { executor, args ->
                 val world: World by args
@@ -78,7 +80,7 @@ fun worldCommand() = commandTree("world") {
     }
 
     literalArgument("join") {
-        worldArgument("world") {
+        worldsArgument("world") {
             withPermission(EssentialsPermissionRegistry.WORLD_COMMAND_JOIN)
             playerExecutor { player, args ->
                 val world: World by args
@@ -122,7 +124,7 @@ fun worldCommand() = commandTree("world") {
     }
 
     literalArgument("delete") {
-        worldArgument("world") {
+        worldsArgument("world") {
             withPermission(EssentialsPermissionRegistry.WORLD_COMMAND_DELETE)
             anyExecutor { executor, args ->
                 val world: World by args
@@ -141,7 +143,7 @@ fun worldCommand() = commandTree("world") {
     }
 
     literalArgument("load") {
-        stringArgument("name") {
+        worldFoldersArgument("name") {
             withPermission(EssentialsPermissionRegistry.WORLD_COMMAND_LOAD)
             anyExecutor { executor, args ->
                 val name: String by args
@@ -161,7 +163,7 @@ fun worldCommand() = commandTree("world") {
     }
 
     literalArgument("unload") {
-        worldArgument("world") {
+        worldsArgument("world") {
             withPermission(EssentialsPermissionRegistry.WORLD_COMMAND_UNLOAD)
             anyExecutor { executor, args ->
                 val world: World by args

--- a/src/main/kotlin/dev/slne/surf/essentials/command/WorldCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/WorldCommand.kt
@@ -1,7 +1,9 @@
 package dev.slne.surf.essentials.command
 
 import dev.jorel.commandapi.kotlindsl.*
+import dev.slne.surf.essentials.command.argument.world.worldEnvironmentArgument
 import dev.slne.surf.essentials.command.argument.world.worldFoldersArgument
+import dev.slne.surf.essentials.command.argument.world.worldTypeArgument
 import dev.slne.surf.essentials.command.argument.world.worldsArgument
 import dev.slne.surf.essentials.service.worldService
 import dev.slne.surf.essentials.util.permission.EssentialsPermissionRegistry
@@ -14,6 +16,7 @@ import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Bukkit
 import org.bukkit.World
+import org.bukkit.WorldType
 import org.bukkit.entity.Player
 
 fun worldCommand() = commandTree("world") {
@@ -125,6 +128,124 @@ fun worldCommand() = commandTree("world") {
                 }
 
                 worldService.create(executor, name, null, null, null, null, null)
+            }
+
+            worldEnvironmentArgument("environment") {
+                anyExecutor { executor, args ->
+                    val name: String by args
+                    val environment: World.Environment by args
+
+                    if (Bukkit.getServer().isFolia()) {
+                        executor.sendText {
+                            appendPrefix()
+                            error("Dieser Befehl wird auf Folia-Servern nicht unterstützt.")
+                        }
+                        return@anyExecutor
+                    }
+
+                    worldService.create(executor, name, environment, null, null, null, null)
+                }
+
+                worldTypeArgument("type") {
+                    anyExecutor { executor, args ->
+                        val name: String by args
+                        val environment: World.Environment by args
+                        val type: WorldType by args
+
+                        if (Bukkit.getServer().isFolia()) {
+                            executor.sendText {
+                                appendPrefix()
+                                error("Dieser Befehl wird auf Folia-Servern nicht unterstützt.")
+                            }
+                            return@anyExecutor
+                        }
+
+                        worldService.create(executor, name, environment, type, null, null, null)
+                    }
+
+                    booleanArgument("generateStructures") {
+                        anyExecutor { executor, args ->
+                            val name: String by args
+                            val environment: World.Environment by args
+                            val type: WorldType by args
+                            val generateStructures: Boolean by args
+
+                            if (Bukkit.getServer().isFolia()) {
+                                executor.sendText {
+                                    appendPrefix()
+                                    error("Dieser Befehl wird auf Folia-Servern nicht unterstützt.")
+                                }
+                                return@anyExecutor
+                            }
+
+                            worldService.create(
+                                executor,
+                                name,
+                                environment,
+                                type,
+                                generateStructures,
+                                null,
+                                null
+                            )
+                        }
+                        booleanArgument("hardcore") {
+                            anyExecutor { executor, args ->
+                                val name: String by args
+                                val environment: World.Environment by args
+                                val type: WorldType by args
+                                val generateStructures: Boolean by args
+                                val hardcore: Boolean by args
+
+                                if (Bukkit.getServer().isFolia()) {
+                                    executor.sendText {
+                                        appendPrefix()
+                                        error("Dieser Befehl wird auf Folia-Servern nicht unterstützt.")
+                                    }
+                                    return@anyExecutor
+                                }
+
+                                worldService.create(
+                                    executor,
+                                    name,
+                                    environment,
+                                    type,
+                                    generateStructures,
+                                    hardcore,
+                                    null
+                                )
+                            }
+
+                            longArgument("seed") {
+                                anyExecutor { executor, args ->
+                                    val name: String by args
+                                    val environment: World.Environment by args
+                                    val type: WorldType by args
+                                    val generateStructures: Boolean by args
+                                    val hardcore: Boolean by args
+                                    val seed: Long by args
+
+                                    if (Bukkit.getServer().isFolia()) {
+                                        executor.sendText {
+                                            appendPrefix()
+                                            error("Dieser Befehl wird auf Folia-Servern nicht unterstützt.")
+                                        }
+                                        return@anyExecutor
+                                    }
+
+                                    worldService.create(
+                                        executor,
+                                        name,
+                                        environment,
+                                        type,
+                                        generateStructures,
+                                        hardcore,
+                                        seed
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/main/kotlin/dev/slne/surf/essentials/command/argument/world/WorldEnvironmentArgument.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/argument/world/WorldEnvironmentArgument.kt
@@ -1,0 +1,45 @@
+package dev.slne.surf.essentials.command.argument.world
+
+import dev.jorel.commandapi.CommandTree
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.arguments.CustomArgument
+import dev.jorel.commandapi.arguments.StringArgument
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import org.bukkit.World
+import org.bukkit.command.CommandSender
+
+class WorldEnvironmentArgument(nodeName: String) :
+    CustomArgument<World.Environment, String>(StringArgument(nodeName), { info ->
+        World.Environment.entries.firstOrNull { it.name == info.input.uppercase() }
+            ?: throw CustomArgumentException.fromAdventureComponent {
+                buildText {
+                    appendPrefix()
+                    error("Das Welt-Umfeld wurde nicht gefunden.")
+                }
+            }
+    }) {
+    init {
+        this.replaceSuggestions(
+            ArgumentSuggestions.stringCollection<CommandSender> {
+                World.Environment.entries.map { it.name.lowercase() }
+            }
+        )
+    }
+}
+
+inline fun Argument<*>.worldEnvironmentArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): Argument<*> = then(
+    WorldEnvironmentArgument(nodeName).setOptional(optional).apply(block)
+)
+
+inline fun CommandTree.worldEnvironmentArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): CommandTree = then(
+    WorldEnvironmentArgument(nodeName).setOptional(optional).apply(block)
+)

--- a/src/main/kotlin/dev/slne/surf/essentials/command/argument/world/WorldFoldersArgument.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/argument/world/WorldFoldersArgument.kt
@@ -1,0 +1,60 @@
+package dev.slne.surf.essentials.command.argument.world
+
+import dev.jorel.commandapi.CommandTree
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.arguments.CustomArgument
+import dev.jorel.commandapi.arguments.StringArgument
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import org.bukkit.Bukkit
+import org.bukkit.command.CommandSender
+import java.io.File
+
+class WorldFoldersArgument(nodeName: String) :
+    CustomArgument<String, String>(StringArgument(nodeName), { info ->
+        if (File(Bukkit.getWorldContainer(), info.input).exists()) {
+            info.input
+        } else {
+            throw CustomArgumentException.fromAdventureComponent {
+                buildText {
+                    appendPrefix()
+                    error("Der Welten-Ordner wurde nicht gefunden.")
+                }
+            }
+        }
+    }) {
+    init {
+        this.replaceSuggestions(
+            ArgumentSuggestions.stringCollection<CommandSender> {
+                Bukkit.getWorldContainer().listFiles().filter { isMinecraftWorldFolder(it) }
+                    .map { it.name }
+            }
+        )
+    }
+}
+
+private fun isMinecraftWorldFolder(folder: File): Boolean {
+    if (!folder.isDirectory) return false
+
+    val levelDat = File(folder, "level.dat")
+    val regionFolder = File(folder, "region")
+
+    return levelDat.exists() && regionFolder.exists() && regionFolder.isDirectory
+}
+
+
+inline fun CommandTree.worldFoldersArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): CommandTree = then(
+    WorldFoldersArgument(nodeName).setOptional(optional).apply(block)
+)
+
+inline fun Argument<*>.worldFoldersArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): Argument<*> = then(
+    WorldFoldersArgument(nodeName).setOptional(optional).apply(block)
+)

--- a/src/main/kotlin/dev/slne/surf/essentials/command/argument/world/WorldTypeArgument.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/argument/world/WorldTypeArgument.kt
@@ -1,0 +1,47 @@
+package dev.slne.surf.essentials.command.argument.world
+
+import dev.jorel.commandapi.CommandTree
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.arguments.CustomArgument
+import dev.jorel.commandapi.arguments.StringArgument
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import org.bukkit.WorldType
+import org.bukkit.command.CommandSender
+
+class WorldTypeArgument(nodeName: String) :
+    CustomArgument<WorldType, String>(StringArgument(nodeName), { info ->
+        WorldType.entries.firstOrNull { it.name == info.input.uppercase() }
+            ?: throw CustomArgumentException.fromAdventureComponent {
+                buildText {
+                    appendPrefix()
+                    error("Der Welttyp wurde nicht gefunden.")
+                }
+            }
+    }) {
+    init {
+        this.replaceSuggestions(
+            ArgumentSuggestions.stringCollection<CommandSender> {
+                WorldType.entries.map {
+                    it.name.lowercase()
+                }
+            }
+        )
+    }
+}
+
+inline fun Argument<*>.worldTypeArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): Argument<*> = then(
+    WorldTypeArgument(nodeName).setOptional(optional).apply(block)
+)
+
+inline fun CommandTree.worldTypeArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): CommandTree = then(
+    WorldTypeArgument(nodeName).setOptional(optional).apply(block)
+)

--- a/src/main/kotlin/dev/slne/surf/essentials/command/argument/world/WorldsArgument.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/argument/world/WorldsArgument.kt
@@ -1,0 +1,45 @@
+package dev.slne.surf.essentials.command.argument.world
+
+import dev.jorel.commandapi.CommandTree
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.arguments.CustomArgument
+import dev.jorel.commandapi.arguments.StringArgument
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import org.bukkit.Bukkit
+import org.bukkit.World
+import org.bukkit.command.CommandSender
+
+class WorldsArgument(nodeName: String) :
+    CustomArgument<World, String>(StringArgument(nodeName), { info ->
+        Bukkit.getWorld(info.input) ?: throw CustomArgumentException.fromAdventureComponent {
+            buildText {
+                appendPrefix()
+                error("Die Welt wurde nicht gefunden.")
+            }
+        }
+    }) {
+    init {
+        this.replaceSuggestions(
+            ArgumentSuggestions.stringCollection<CommandSender> {
+                Bukkit.getWorlds().map { it.name }
+            }
+        )
+    }
+}
+
+inline fun CommandTree.worldsArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): CommandTree = then(
+    WorldsArgument(nodeName).setOptional(optional).apply(block)
+)
+
+inline fun Argument<*>.worldsArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): Argument<*> = then(
+    WorldsArgument(nodeName).setOptional(optional).apply(block)
+)


### PR DESCRIPTION
This pull request introduces significant enhancements and refactoring to the world management commands in the Essentials module. The main focus is on improving command argument handling by introducing custom argument types for worlds, world environments, world types, and world folders. Additionally, the `world` command tree is expanded for more flexible world creation and management, and a new paginated world listing feature is added for better usability.

**Command Argument Improvements:**

* Introduced new custom argument classes: `WorldsArgument`, `WorldEnvironmentArgument`, `WorldTypeArgument`, and `WorldFoldersArgument`, each providing improved validation and tab-completion for their respective world-related command arguments. [[1]](diffhunk://#diff-f6c27d55b1147683e2ec3f5211aee4c1810aef6e79c2c5ef32beaa463228aee2R1-R45) [[2]](diffhunk://#diff-5f34bce0beb1ce3797dca601d29557244a69a3ff4c88c3bd3ccf33c304c4e2bbR1-R45) [[3]](diffhunk://#diff-e16bfd420ded71d9009d96a104ae55c9fa611287b16ec3fbc9e1f3e73e15bbe0R1-R47) [[4]](diffhunk://#diff-40d2a693c8f20a5d33588164412d84e9179ad6d3d4730ed537542f15f1356e41R1-R60)
* Updated all usages of world-related arguments in `WorldCommand.kt` to use these new argument types, ensuring more robust and user-friendly command parsing. [[1]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6R4-R26) [[2]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L48-R59) [[3]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L81-R92) [[4]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6R122-R136) [[5]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L125-R257) [[6]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L156-R273) [[7]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L176-R404)

**World Command Enhancements:**

* Refactored the `world create` command to support a stepwise argument addition flow, allowing users to specify environment, type, structure generation, hardcore mode, and seed in a nested, guided manner. Each step includes validation and user feedback. [[1]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6R122-R136) [[2]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L125-R257)
* Added a paginated `world list` command that displays loaded worlds, their lock status, and allows players to teleport to a selected world via clickable entries.

**Other Changes:**

* Updated the project version in `gradle.properties` to `1.21.10-2.0.5-SNAPSHOT`.
* Minor import adjustment in `WorldService.kt` to include `CompletableFuture`

These changes collectively improve the extensibility, user experience, and maintainability of the world's command system.

**References:** [[1]](diffhunk://#diff-f6c27d55b1147683e2ec3f5211aee4c1810aef6e79c2c5ef32beaa463228aee2R1-R45) [[2]](diffhunk://#diff-5f34bce0beb1ce3797dca601d29557244a69a3ff4c88c3bd3ccf33c304c4e2bbR1-R45) [[3]](diffhunk://#diff-e16bfd420ded71d9009d96a104ae55c9fa611287b16ec3fbc9e1f3e73e15bbe0R1-R47) [[4]](diffhunk://#diff-40d2a693c8f20a5d33588164412d84e9179ad6d3d4730ed537542f15f1356e41R1-R60) [[5]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6R4-R26) [[6]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L48-R59) [[7]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L81-R92) [[8]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6R122-R136) [[9]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L125-R257) [[10]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L156-R273) [[11]](diffhunk://#diff-e47d2887ccb2ec6cbdb16699722c35df512de77d791a8ba281eb6d69ddd284d6L176-R404) [[12]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L4-R4) [[13]](diffhunk://#diff-68fcfb4c7d9e206333a7b11df189bcea32765e68bf2d3b20f3f70ebfacad8572R9)