### PR TITLE
feat: conditionally enable special commands based on server type

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.10-2.0.5-SNAPSHOT
+version=1.21.10-2.0.6-SNAPSHOT

--- a/src/main/kotlin/dev/slne/surf/essentials/PaperCommandManager.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/PaperCommandManager.kt
@@ -25,7 +25,6 @@ object PaperCommandManager {
         giveCommand()
         infoCommand()
         itemEditCommand()
-        signCommand()
         teleportCommand()
         teleportOfflineCommand()
         teleportRandomCommand()
@@ -62,7 +61,12 @@ object PaperCommandManager {
         soundCommand()
         stopCommand()
         restartCommand()
-        makeSpecialCommand()
+
+        if (!plugin.isSurvivalServer()) {
+            makeSpecialCommand()
+            signCommand()
+        }
+
         knightCommand()
         toolCommand()
         experienceCommand()

--- a/src/main/kotlin/dev/slne/surf/essentials/PaperMain.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/PaperMain.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.essentials
 
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
+import dev.slne.surf.surfapi.bukkit.api.extensions.pluginManager
 import org.bukkit.plugin.java.JavaPlugin
 
 val plugin get() = JavaPlugin.getPlugin(PaperMain::class.java)
@@ -18,4 +19,6 @@ class PaperMain : SuspendingJavaPlugin() {
     override fun onDisable() {
         super.onDisable()
     }
+
+    fun isSurvivalServer() = pluginManager.isPluginEnabled("surf-freebuild-bukkit")
 }

--- a/src/main/kotlin/dev/slne/surf/essentials/listener/SpecialItemListener.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/listener/SpecialItemListener.kt
@@ -1,5 +1,6 @@
 package dev.slne.surf.essentials.listener
 
+import dev.slne.surf.essentials.plugin
 import dev.slne.surf.essentials.service.specialItemService
 import dev.slne.surf.essentials.util.util.appendNewLineArrow
 import dev.slne.surf.essentials.util.util.translatable
@@ -27,6 +28,10 @@ object SpecialItemListener : Listener {
     fun onPickup(event: EntityPickupItemEvent) {
         val player = event.entity as? Player ?: return
         val itemStack = event.item.itemStack
+
+        if (plugin.isSurvivalServer()) {
+            return
+        }
 
         if (!specialItemService.isSpecial(itemStack)) {
             return


### PR DESCRIPTION
This pull request introduces conditional logic to enable or disable certain features depending on whether the server is running in survival mode (specifically, if the `surf-freebuild-bukkit` plugin is enabled). The main changes involve restricting access to special commands and items on survival servers to ensure appropriate gameplay boundaries.

**Survival server detection and feature gating:**

* Added the `isSurvivalServer()` method to `PaperMain`, which checks for the presence of the `surf-freebuild-bukkit` plugin. This method is now used throughout the codebase to conditionally enable or disable features.

**Command registration changes:**

* Moved registration of `signCommand` and `makeSpecialCommand` in `PaperCommandManager` to only occur when the server is not in survival mode, preventing their use on survival servers. [[1]](diffhunk://#diff-c1e3136cade7d519e3f64eda2193266136f82a9f5eeda4859fec9c5be9c80c98L28) [[2]](diffhunk://#diff-c1e3136cade7d519e3f64eda2193266136f82a9f5eeda4859fec9c5be9c80c98R64-R69)

**Special item usage restriction:**

* Updated `SpecialItemListener` to prevent usage of special items by players if the server is in survival mode, further enforcing gameplay boundaries.

**Imports and code organization:**

* Added necessary imports for `pluginManager` and `plugin` to support the new conditional logic. [[1]](diffhunk://#diff-f50df40ecf8b4a8257dc6de0ccb069ef9c605ac9ba8dee1b48ad4ed8ecc1bc5bR4) [[2]](diffhunk://#diff-164e34e453c74bb4a8312f2107fda35adcec8934d27f16e3e7a46d3bbacd525eR3)