### PR TITLE
Feat/add ping command

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.10-2.0.5-SNAPSHOT
+version=1.21.10-2.0.6-SNAPSHOT

--- a/src/main/kotlin/dev/slne/surf/essentials/PaperCommandManager.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/PaperCommandManager.kt
@@ -71,5 +71,6 @@ object PaperCommandManager {
         timeCommand()
         skinChangeCommand()
         worldCommand()
+        pingCommand()
     }
 }

--- a/src/main/kotlin/dev/slne/surf/essentials/command/PingCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/PingCommand.kt
@@ -29,7 +29,7 @@ fun pingCommand() = commandTree("ping") {
             executor.sendText {
                 appendPrefix()
                 variableValue(target.name)
-                info("hat einen Ping von ")
+                info(" hat einen Ping von ")
                 coloredPing(ping)
                 info(".")
             }

--- a/src/main/kotlin/dev/slne/surf/essentials/command/PingCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/PingCommand.kt
@@ -1,0 +1,38 @@
+package dev.slne.surf.essentials.command
+
+import dev.jorel.commandapi.kotlindsl.*
+import dev.slne.surf.essentials.util.permission.EssentialsPermissionRegistry
+import dev.slne.surf.essentials.util.util.coloredPing
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import org.bukkit.entity.Player
+
+fun pingCommand() = commandTree("ping") {
+    withPermission(EssentialsPermissionRegistry.PING_COMMAND)
+    playerExecutor { player, _ ->
+        val ping = player.ping.toLong()
+
+        player.sendText {
+            appendPrefix()
+            info("Du hast einen Ping von ")
+            coloredPing(ping)
+            info(".")
+        }
+    }
+
+    entitySelectorArgumentOnePlayer("target") {
+        withPermission(EssentialsPermissionRegistry.PING_COMMAND_OTHER)
+        anyExecutor { executor, args ->
+            val target: Player by args
+
+            val ping = target.ping.toLong()
+
+            executor.sendText {
+                appendPrefix()
+                variableValue(target.name)
+                info("hat einen Ping von ")
+                coloredPing(ping)
+                info(".")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/essentials/util/permission/EssentialsPermissionRegistry.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/util/permission/EssentialsPermissionRegistry.kt
@@ -108,4 +108,6 @@ object EssentialsPermissionRegistry : PermissionRegistry() {
     val WORLD_COMMAND_LIST = create("$PREFIX.world.command.list")
     val WORLD_COMMAND_JOIN = create("$PREFIX.world.command.join")
     val WORLD_BYPASS = create("$PREFIX.world.bypass")
+    val PING_COMMAND = create("$PREFIX.ping.command")
+    val PING_COMMAND_OTHER = create("$PREFIX.ping.command.other")
 }

--- a/src/main/kotlin/dev/slne/surf/essentials/util/util/surf-util.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/util/util/surf-util.kt
@@ -90,3 +90,49 @@ fun Duration.userContent(): String {
 
     return parts.joinToString(", ")
 }
+
+fun SurfComponentBuilder.coloredDuration(
+    duration: Duration,
+    good: Duration = Duration.ofMillis(200),
+    okay: Duration = Duration.ofMillis(1000)
+) {
+    val millis = duration.toMillis()
+    when {
+        duration < good -> text(
+            millis.toString() + "ms",
+            Colors.GREEN
+        )
+
+        duration < okay -> text(
+            millis.toString() + "ms",
+            Colors.YELLOW
+        )
+
+        else -> text(millis.toString() + "ms", Colors.RED)
+    }
+}
+
+fun SurfComponentBuilder.coloredPing(
+    ping: Long
+) = coloredDuration(Duration.ofMillis(ping), Duration.ofMillis(100), Duration.ofMillis(300))
+
+fun Long.coloredComponent(good: Long = 200L, okay: Long = 1000L) =
+    buildText {
+        when {
+            this@coloredComponent < good -> append(
+                Component.text(
+                    this@coloredComponent.toString() + "ms",
+                    Colors.GREEN
+                )
+            )
+
+            this@coloredComponent < okay -> append(
+                Component.text(
+                    this@coloredComponent.toString() + "ms",
+                    Colors.YELLOW
+                )
+            )
+
+            else -> append(Component.text(this@coloredComponent.toString() + "ms", Colors.RED))
+        }
+    }


### PR DESCRIPTION
This pull request introduces a new `/ping` command that allows players to check their own or another player's ping, with ping values color-coded for clarity. Supporting utilities and permissions have been added to ensure proper access control and user-friendly display. The project version is also incremented.

**New ping command and supporting features:**

* Added a new `pingCommand` in `PingCommand.kt`, allowing players to check their own ping or another player's ping if they have the appropriate permission. The output is color-coded based on the ping value.
* Registered the `pingCommand` in the `PaperCommandManager` so it is available in-game.

**Permission management:**

* Introduced new permissions `PING_COMMAND` and `PING_COMMAND_OTHER` in `EssentialsPermissionRegistry` to control access to the ping command and its ability to check other players' pings.

**Utility enhancements:**

* Added `coloredDuration`, `coloredPing`, and `coloredComponent` utility functions in `surf-util.kt` to provide consistent, color-coded formatting for durations and ping values.

**Version update:**

* Bumped the project version to `1.21.10-2.0.6-SNAPSHOT` in `gradle.properties`.