### PR TITLE
Update success message for Stonecutter command

### DIFF
--- a/src/main/kotlin/dev/slne/surf/essentials/command/table/StonecutterCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/table/StonecutterCommand.kt
@@ -13,7 +13,7 @@ fun stoneCutterCommand() = commandTree("stonecutter") {
         player.openStonecutter(null, true)
         player.sendText {
             appendSuccessPrefix()
-            success("Du hast eine Steinschneidemaschine geöffnet.")
+            success("Du hast eine Steinsäge geöffnet.")
         }
     }
 }


### PR DESCRIPTION
This pull request updates the success message shown to players when they open the stonecutter interface, making the terminology more accurate.

Text update for user feedback:

* Changed the success message in `StonecutterCommand.kt` from "Du hast eine Steinschneidemaschine geöffnet." to "Du hast eine Steinsäge geöffnet." to use the correct term for the stonecutter.