### PR TITLE
Fix Hat command ignoring binding curse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+run/
+
 ### IntelliJ IDEA ###
 .idea/modules.xml
 .idea/jarRepositories.xml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import dev.slne.surf.api.gradle.util.registerRequired
+import dev.slne.surf.api.gradle.util.withSurfApiBukkit
 
 plugins {
     id("dev.slne.surf.api.gradle.paper-plugin")
@@ -19,6 +20,14 @@ surfPaperPluginApi {
     }
 
     authors.addAll("twisti", "red", "mikey")
+
+    runServer {
+        withSurfApiBukkit()
+    }
+}
+
+runPaper {
+    folia.registerTask()
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=3.3.1
+version=3.3.2

--- a/src/main/kotlin/dev/slne/surf/essentials/command/HatCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/command/HatCommand.kt
@@ -1,18 +1,33 @@
 package dev.slne.surf.essentials.command
 
+import dev.jorel.commandapi.CommandAPIPaper
 import dev.jorel.commandapi.kotlindsl.commandTree
 import dev.jorel.commandapi.kotlindsl.entitySelectorArgumentOnePlayer
 import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.slne.surf.api.core.messages.adventure.buildText
 import dev.slne.surf.api.core.messages.adventure.sendText
 import dev.slne.surf.essentials.util.permission.EssentialsPermissionRegistry
+import io.papermc.paper.datacomponent.DataComponentTypes
+import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
 
 fun hatCommand() = commandTree("hat") {
     withPermission(EssentialsPermissionRegistry.HAT_COMMAND)
     playerExecutor { player, _ ->
         val itemInHand = player.inventory.itemInMainHand
         val helmet = player.inventory.helmet
+
+        if (!player.hasPermission(EssentialsPermissionRegistry.HAT_COMMAND_BYPASS)) {
+            if (helmet.isPreventArmorChange()) {
+                throw CommandAPIPaper.failWithAdventureComponent(buildText {
+                    appendErrorPrefix()
+                    error("Du kannst deinen Hut nicht verändern!")
+                })
+            }
+        }
+
         player.inventory.setHelmet(itemInHand)
         player.inventory.setItemInMainHand(helmet)
 
@@ -34,6 +49,17 @@ fun hatCommand() = commandTree("hat") {
             val player: Player by args
             val itemInHand = executor.inventory.itemInMainHand
             val helmet = player.inventory.helmet
+
+            if (!executor.hasPermission(EssentialsPermissionRegistry.HAT_COMMAND_BYPASS)) {
+                if (helmet.isPreventArmorChange()) {
+                    throw CommandAPIPaper.failWithAdventureComponent(buildText {
+                        appendErrorPrefix()
+                        variableValue(player.name)
+                        error("s Hut kann nicht verändert werden!")
+                    })
+                }
+            }
+
             player.inventory.setHelmet(itemInHand)
             player.inventory.setItemInMainHand(helmet)
 
@@ -60,4 +86,10 @@ fun hatCommand() = commandTree("hat") {
             }
         }
     }
+}
+
+@Suppress("UnstableApiUsage")
+private fun ItemStack.isPreventArmorChange(): Boolean {
+    val enchantments = getData(DataComponentTypes.ENCHANTMENTS) ?: return false
+    return enchantments.enchantments().keys.any { it.key() == Enchantment.BINDING_CURSE.key() }
 }

--- a/src/main/kotlin/dev/slne/surf/essentials/util/permission/EssentialsPermissionRegistry.kt
+++ b/src/main/kotlin/dev/slne/surf/essentials/util/permission/EssentialsPermissionRegistry.kt
@@ -22,6 +22,7 @@ object EssentialsPermissionRegistry : PermissionRegistry() {
     val HEAL_COMMAND_OTHERS = create("$PREFIX.heal.command.others")
     val HAT_COMMAND = create("$PREFIX.hat.command")
     val HAT_COMMAND_OTHERS = create("$PREFIX.hat.command.others")
+    val HAT_COMMAND_BYPASS = create("$PREFIX.hat.command.bypass")
     val LIST_COMMAND = create("$PREFIX.list.command")
     val LIST_COMMAND_WORLD = create("$PREFIX.list.command.world")
     val TRASH_COMMAND = create("$PREFIX.trash.command")


### PR DESCRIPTION
This pull request updates the `hat` command to prevent players from swapping their helmet if it has the Curse of Binding enchantment, unless they have a specific bypass permission. It also introduces a new permission for bypassing this restriction and bumps the project version.

**Hat command improvements:**

* Added a check in `HatCommand.kt` to prevent players from changing their helmet if it has the Curse of Binding enchantment, unless they have the `hat.command.bypass` permission. This ensures players can't remove bound helmets unintentionally. [[1]](diffhunk://#diff-6a1cf6d1533613bf741565bec875beca6a226196fe3d94570e51d2ba1f1b7cfaR3-R30) [[2]](diffhunk://#diff-6a1cf6d1533613bf741565bec875beca6a226196fe3d94570e51d2ba1f1b7cfaR52-R62)
* Implemented a private extension function `isPreventArmorChange` on `ItemStack` to detect the Curse of Binding enchantment using Paper's DataComponent API.

**Permissions:**

* Added a new permission node `hat.command.bypass` to `EssentialsPermissionRegistry` for allowing certain players to bypass the Curse of Binding restriction.

**Versioning:**

* Bumped the project version from `3.3.1` to `3.3.2` in `gradle.properties`.

Fixes #53 